### PR TITLE
docs(api): add CI status badge to README

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/Armandomateus41/digital_backend/actions/workflows/ci.yml/badge.svg)](https://github.com/Armandomateus41/digital_backend/actions/workflows/ci.yml)
+
 <p align="center">
   <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
 </p>


### PR DESCRIPTION
Adiciona badge do GitHub Actions (ci.yml) no apps/api/README.md
Sem mudanças funcionais; apenas documentação
CI já validado (build-and-test verde)
Checklist: lint/typecheck/test ok; sem mudanças de API; sem migrações