### PR TITLE
ci(codecov): add project/patch coverage thresholds (60%) and ignores

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0.60
+        threshold: 0.01
+        informational: false
+    patch:
+      default:
+        target: auto
+        threshold: 0.005
+        only_pulls: true
+        informational: false
+ignore:
+  - apps/api/dist/**
+  - apps/api/coverage/**
+  - apps/api/test/**
+  - "**/*.d.ts"


### PR DESCRIPTION
Título: ci(codecov): enforce coverage thresholds (60%)
Descrição (cole):
Adiciona codecov.yml (project 60%, patch auto, thresholds pequenos)
Ignora dist/coverage/test/.d.ts
Sem mudanças de produto; CI permanece verde
Crie o PR, aguarde o CI e faça Squash and merge. Depois, delete a branch.